### PR TITLE
Build continuous builds on Cirrus CI and upload to GitHub Releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+freebsd_instance:
+  image: freebsd-12-1-release-amd64
+
+env:
+  CIRRUS_CLONE_DEPTH: 1
+  GITHUB_TOKEN: ENCRYPTED[!0f42e3f70fd51cdeddfe7e98160982fc9efe7e8a26869b725fcd5de05d067a7100b994cf52f0f1b470a983148e0b8ec2!]
+  
+task:
+  # This name gets reported as a build status in GitHub
+  name: freebsd-12-1-release-amd64
+  auto_cancellation: false
+  stateful: false
+  setup_script:
+    - pkg install -y curl wget zip pkgconf cmake qt5-buildtools qt5-core qt5-linguisttools qt5-qmake qt5-gui qt5-widgets
+  test_script:
+    - mkdir build ; cd build
+    - qmake ..
+    - make -j$(sysctl -n hw.ncpu)
+    - zip --symlinks -r dsbexec_FreeBSD.zip dsbexec
+    - case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) wget https://github.com/tcnksm/ghr/files/5247714/ghr.zip ; unzip ghr.zip ; rm ghr.zip ; ./ghr -delete -t "${GITHUB_TOKEN}" -u "${CIRRUS_REPO_OWNER}" -r "${CIRRUS_REPO_NAME}" -c "${CIRRUS_CHANGE_IN_REPO}" continuous "${CIRRUS_WORKING_DIR}"/build/*zip ; esac
+  only_if: $CIRRUS_TAG != 'continuous'


### PR DESCRIPTION
This PR, when merged, will build continuous builds on Cirrus CI and upload them to GitHub Releases.